### PR TITLE
Fix: WebSocket connection failing through Cloudflare Tunnel

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net"
@@ -118,6 +119,7 @@ func (s *Server) startHTTPServer() error {
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  120 * time.Second,
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary
- Disabled HTTP/2 on the Go HTTP server by setting `TLSNextProto` to an empty map
- Cloudflare Tunnel negotiates HTTP/2 with the origin, but `gorilla/websocket` only supports HTTP/1.1 upgrades, causing all browser WebSocket connections to fail with 400
- This forces the tunnel to use HTTP/1.1 for the WebSocket upgrade handshake

## Test plan
- [ ] Deploy and verify `wss://ans.kirjaswappi.fi/ws?userId=<id>` connects successfully from the browser
- [ ] Verify notification WebSocket reconnection loop no longer occurs in the browser console
- [ ] Verify health check endpoint still responds at `/healthz`