### PR TITLE
Fix: notification service bug sweep

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -150,16 +151,21 @@ func (s *Server) startHTTPServer() error {
 	mux.Handle("/stats", s.loggingMiddleware(s.requireAPIKey(http.HandlerFunc(s.statsHandler))))
 
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.config.HTTPPort),
 		Handler:      mux,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
 
+	addr := fmt.Sprintf(":%d", s.config.HTTPPort)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on HTTP port %d: %w", s.config.HTTPPort, err)
+	}
+
+	s.logger.Info("HTTP server started", slog.Int("port", s.config.HTTPPort))
 	go func() {
-		s.logger.Info("HTTP server started", slog.Int("port", s.config.HTTPPort))
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			s.logger.Error("HTTP server failed", slog.String("error", err.Error()))
 		}
 	}()

--- a/internal/delivery/grpc/notification_handler.go
+++ b/internal/delivery/grpc/notification_handler.go
@@ -45,13 +45,15 @@ func (h *NotificationHandler) SendNotification(ctx context.Context, req *pb.Noti
 	delivered := h.broadcaster.Broadcast(notification)
 	if delivered == 0 {
 		h.logger.Warn("notification delivered to zero subscribers",
-			slog.String("userId", req.UserId),
+			slog.String("user_id", req.UserId),
 			slog.String("title", req.Title))
+		return &pb.NotificationResponse{Success: false}, nil
 	}
 
 	h.logger.Info("Notification sent",
 		slog.String("user_id", req.UserId),
-		slog.String("title", req.Title))
+		slog.String("title", req.Title),
+		slog.Int("delivered", delivered))
 
 	return &pb.NotificationResponse{Success: delivered > 0}, nil
 }

--- a/internal/delivery/grpc/notification_handler.go
+++ b/internal/delivery/grpc/notification_handler.go
@@ -42,13 +42,18 @@ func (h *NotificationHandler) SendNotification(ctx context.Context, req *pb.Noti
 		Time:    req.GetTime().AsTime(),
 	}
 
-	h.broadcaster.Broadcast(notification)
+	delivered := h.broadcaster.Broadcast(notification)
+	if delivered == 0 {
+		h.logger.Warn("notification delivered to zero subscribers",
+			slog.String("userId", req.UserId),
+			slog.String("title", req.Title))
+	}
 
 	h.logger.Info("Notification sent",
 		slog.String("user_id", req.UserId),
 		slog.String("title", req.Title))
 
-	return &pb.NotificationResponse{Success: true}, nil
+	return &pb.NotificationResponse{Success: delivered > 0}, nil
 }
 
 func (h *NotificationHandler) validateRequest(req *pb.NotificationRequest) error {

--- a/internal/service/broadcaster.go
+++ b/internal/service/broadcaster.go
@@ -70,12 +70,12 @@ func (b *Broadcaster) Unsubscribe(userID string, ch Subscriber) {
 	}
 }
 
-func (b *Broadcaster) Broadcast(n domain.Notification) {
+func (b *Broadcaster) Broadcast(n domain.Notification) int {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
 	if b.closed {
-		return
+		return 0
 	}
 
 	subscribers := b.subscribers[n.UserID]
@@ -83,7 +83,7 @@ func (b *Broadcaster) Broadcast(n domain.Notification) {
 		b.logger.Debug("No subscribers for notification",
 			slog.String("user_id", n.UserID),
 			slog.String("title", n.Title))
-		return
+		return 0
 	}
 
 	delivered := 0
@@ -114,6 +114,8 @@ func (b *Broadcaster) Broadcast(n domain.Notification) {
 				slog.Int("dropped", dropped))
 		}
 	}
+
+	return delivered
 }
 
 func (b *Broadcaster) Close() {

--- a/internal/service/broadcaster_test.go
+++ b/internal/service/broadcaster_test.go
@@ -102,3 +102,32 @@ func TestBroadcasterMultipleSubscribers(t *testing.T) {
 		t.Errorf("Expected 2 subscribers, got %d", subs)
 	}
 }
+
+func TestBroadcastReturnsZeroWithNoSubscribers(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	b := NewBroadcaster(logger)
+	defer b.Close()
+
+	n := domain.Notification{UserID: "user-1", Title: "Test", Message: "msg", Time: time.Now()}
+	delivered := b.Broadcast(n)
+	if delivered != 0 {
+		t.Errorf("Expected 0 delivered with no subscribers, got %d", delivered)
+	}
+}
+
+func TestBroadcastReturnsDeliveredCount(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	b := NewBroadcaster(logger)
+	defer b.Close()
+
+	ch1 := b.Subscribe("user-1")
+	ch2 := b.Subscribe("user-1") // same user, 2 subscribers
+	n := domain.Notification{UserID: "user-1", Title: "Test", Message: "msg", Time: time.Now()}
+	delivered := b.Broadcast(n)
+	if delivered != 2 {
+		t.Errorf("Expected 2 delivered, got %d", delivered)
+	}
+	// drain
+	<-ch1
+	<-ch2
+}


### PR DESCRIPTION
Fixes the following findings from the parallel bug review (see BUG_FINDINGS.md):

- L10: HTTP server bind failure was swallowed — net.Listen now called synchronously before goroutine launch, bind errors abort startup with non-zero exit (matches gRPC path behavior)
- L11: gRPC SendNotification returned Success: true even with zero subscribers (notification dropped to no-listener) — Broadcast now returns delivered count; handler returns Success: false and logs a warning when count is zero