### PR TITLE
Docs: rewrite README and add proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2024–2026 KirjaSwappi. All rights reserved.
+
+This software and its source code are the proprietary and confidential
+property of KirjaSwappi. No part of this software may be used, copied,
+modified, merged, published, distributed, sublicensed, or sold in any
+form or by any means without the prior written permission of KirjaSwappi.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL
+KIRJASWAPPI BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING
+FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR ITS USE.
+
+For licensing enquiries, contact: info@kirjaswappi.fi


### PR DESCRIPTION
- Rewrites README: architecture diagram, tech stack table, configuration table, endpoints table, Docker instructions, related repos
- Adds proprietary LICENSE (previously missing)